### PR TITLE
Add support to override headers in Java client for each request

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -1218,13 +1218,12 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP call
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, callback);
 
         return httpClient.newCall(request);
     }
@@ -1240,13 +1239,11 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
-    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
+    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
 
         final String url = buildUrl(path, queryParams, collectionQueryParams);
         final Request.Builder reqBuilder = new Request.Builder().url(url);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -96,7 +96,7 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback _callback) throws ApiException {
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Call({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
 
         // create path and map variables
@@ -172,14 +172,20 @@ public class {{classname}} {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{^-last}}, {{/-last}}{{/authMethods}} };
-        return localVarApiClient.buildCall(localVarPath, {{^dynamicOperations}}"{{httpMethod}}"{{/dynamicOperations}}{{#dynamicOperations}}apiOperation.getMethod(){{/dynamicOperations}}, localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, {{^dynamicOperations}}"{{httpMethod}}"{{/dynamicOperations}}{{#dynamicOperations}}apiOperation.getMethod(){{/dynamicOperations}}, localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call {{operationId}}ValidateBeforeCall({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call {{operationId}}ValidateBeforeCall({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         {{^performBeanValidation}}
         {{#allParams}}{{#required}}
         // verify the required parameter '{{paramName}}' is set
@@ -188,7 +194,7 @@ public class {{classname}} {
         }
         {{/required}}{{/allParams}}
 
-        okhttp3.Call localVarCall = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+        okhttp3.Call localVarCall = {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}headers, _callback);
         return localVarCall;
 
         {{/performBeanValidation}}
@@ -257,6 +263,7 @@ public class {{classname}} {
      * {{summary}}
      * {{notes}}{{#allParams}}
      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}){{/required}}{{/allParams}}
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      {{#responses.0}}
@@ -279,10 +286,14 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
-        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null);
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}, {{/allParams}}Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}headers, null);
         {{#returnType}}Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);{{/returnType}}{{^returnType}}return localVarApiClient.execute(localVarCall);{{/returnType}}
+    }
+
+    {{^vendorExtensions.x-group-parameters}}public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+        return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}null);
     }
 
     {{^vendorExtensions.x-group-parameters}}/**
@@ -312,13 +323,26 @@ public class {{classname}} {
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
-    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> _callback) throws ApiException {
+    public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}Map<String, String> headers, final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+        okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}headers, _callback);
         {{#returnType}}Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);{{/returnType}}{{^returnType}}localVarApiClient.executeAsync(localVarCall, _callback);{{/returnType}}
         return localVarCall;
     }
+
+    {{^vendorExtensions.x-group-parameters}}
+    {{#isDeprecated}}
+            @Deprecated
+    {{/isDeprecated}}
+        public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} okhttp3.Call {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}final ApiCallback<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = {{operationId}}ValidateBeforeCall({{#allParams}}{{paramName}}, {{/allParams}}null, _callback);
+{{#returnType}}Type localVarReturnType = new TypeToken<{{{returnType}}}>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);{{/returnType}}{{^returnType}}localVarApiClient.executeAsync(localVarCall, _callback);{{/returnType}}
+    return localVarCall;
+    }
+
     {{#vendorExtensions.x-group-parameters}}
 
     public class API{{operationId}}Request {
@@ -369,7 +393,7 @@ public class {{classname}} {
         @Deprecated
         {{/isDeprecated}}
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}_callback);
+            return {{operationId}}Call({{#allParams}}{{paramName}}, {{/allParams}}null, _callback);
         }
 
         /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -254,8 +254,12 @@ public class {{classname}} {
     @Deprecated
     {{/isDeprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
-        {{#returnType}}ApiResponse<{{{returnType}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});{{#returnType}}
-        return localVarResp.getData();{{/returnType}}
+        {{#returnType}}ApiResponse<{{{returnType}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}null);
+        {{#returnType}}return localVarResp.getData();{{/returnType}}
+    }
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}, {{/allParams}}Map<String, String> headers) throws ApiException {
+      {{#returnType}}ApiResponse<{{{returnType}}}> localVarResp = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}, {{/allParams}}headers);
+        {{#returnType}}return localVarResp.getData();{{/returnType}}
     }
     {{/vendorExtensions.x-group-parameters}}
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
@@ -1109,13 +1109,12 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP call
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, callback);
 
         return httpClient.newCall(request);
     }
@@ -1131,13 +1130,11 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
-    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
+    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
 
         final String url = buildUrl(path, queryParams, collectionQueryParams);
         final Request.Builder reqBuilder = new Request.Builder().url(url);

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -140,7 +140,11 @@ public class AnotherFakeApi {
      </table>
      */
     public Client call123testSpecialTags(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client call123testSpecialTags(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -69,7 +69,7 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -104,11 +104,17 @@ public class AnotherFakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -116,7 +122,7 @@ public class AnotherFakeApi {
         }
         
 
-        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -142,6 +148,7 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -150,10 +157,14 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null);
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
+        return call123testSpecialTagsWithHttpInfo(body, null);
     }
 
     /**
@@ -169,11 +180,20 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -147,7 +147,12 @@ public class FakeApi {
      </table>
      */
     public void createXmlItem(XmlItem xmlItem) throws ApiException {
-        createXmlItemWithHttpInfo(xmlItem);
+        createXmlItemWithHttpInfo(xmlItem, null);
+        
+    }
+    public void createXmlItem(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+      createXmlItemWithHttpInfo(xmlItem, headers);
+        
     }
 
     /**
@@ -277,7 +282,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
-        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body);
+        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Boolean fakeOuterBooleanSerialize(Boolean body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -411,7 +420,11 @@ Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
      </table>
      */
     public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
-        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body);
+        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public OuterComposite fakeOuterCompositeSerialize(OuterComposite body, Map<String, String> headers) throws ApiException {
+      ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -545,7 +558,11 @@ Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
      </table>
      */
     public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
-        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body);
+        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public BigDecimal fakeOuterNumberSerialize(BigDecimal body, Map<String, String> headers) throws ApiException {
+      ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -679,7 +696,11 @@ Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
      </table>
      */
     public String fakeOuterStringSerialize(String body) throws ApiException {
-        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body);
+        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public String fakeOuterStringSerialize(String body, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -817,7 +838,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
-        testBodyWithFileSchemaWithHttpInfo(body);
+        testBodyWithFileSchemaWithHttpInfo(body, null);
+        
+    }
+    public void testBodyWithFileSchema(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+      testBodyWithFileSchemaWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -959,7 +985,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testBodyWithQueryParams(String query, User body) throws ApiException {
-        testBodyWithQueryParamsWithHttpInfo(query, body);
+        testBodyWithQueryParamsWithHttpInfo(query, body, null);
+        
+    }
+    public void testBodyWithQueryParams(String query, User body, Map<String, String> headers) throws ApiException {
+      testBodyWithQueryParamsWithHttpInfo(query, body, headers);
+        
     }
 
     /**
@@ -1096,7 +1127,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Client testClientModel(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClientModel(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -1333,7 +1368,12 @@ Type localVarReturnType = new TypeToken<Client>(){}.getType();
      </table>
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+        
+    }
+    public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+      testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers);
+        
     }
 
     /**
@@ -1520,7 +1560,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+        
+    }
+    public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+      testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers);
+        
     }
 
     /**
@@ -1887,7 +1932,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
-        testInlineAdditionalPropertiesWithHttpInfo(param);
+        testInlineAdditionalPropertiesWithHttpInfo(param, null);
+        
+    }
+    public void testInlineAdditionalProperties(Map<String, String> param, Map<String, String> headers) throws ApiException {
+      testInlineAdditionalPropertiesWithHttpInfo(param, headers);
+        
     }
 
     /**
@@ -2036,7 +2086,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testJsonFormData(String param, String param2) throws ApiException {
-        testJsonFormDataWithHttpInfo(param, param2);
+        testJsonFormDataWithHttpInfo(param, param2, null);
+        
+    }
+    public void testJsonFormData(String param, String param2, Map<String, String> headers) throws ApiException {
+      testJsonFormDataWithHttpInfo(param, param2, headers);
+        
     }
 
     /**
@@ -2205,7 +2260,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
+        
+    }
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+      testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -77,7 +77,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = xmlItem;
 
         // create path and map variables
@@ -112,11 +112,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'xmlItem' is set
         if (xmlItem == null) {
@@ -124,7 +130,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, headers, _callback);
         return localVarCall;
 
     }
@@ -148,6 +154,7 @@ public class FakeApi {
      * creates an XmlItem
      * this route creates an XmlItem
      * @param xmlItem XmlItem Body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -156,9 +163,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null);
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
+        return createXmlItemWithHttpInfo(xmlItem, null);
     }
 
     /**
@@ -174,12 +185,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterBooleanSerialize
      * @param body Input boolean as post body (optional)
@@ -192,7 +211,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -227,14 +246,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -260,6 +285,7 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * @param body Input boolean as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Boolean&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -268,10 +294,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
+        return fakeOuterBooleanSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -287,13 +317,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, Map<String, String> headers, final ApiCallback<Boolean> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterCompositeSerialize
      * @param body Input composite as post body (optional)
@@ -306,7 +345,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -341,14 +380,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -374,6 +419,7 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * @param body Input composite as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;OuterComposite&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -382,10 +428,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null);
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
+        return fakeOuterCompositeSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -401,13 +451,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, Map<String, String> headers, final ApiCallback<OuterComposite> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterNumberSerialize
      * @param body Input number as post body (optional)
@@ -420,7 +479,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -455,14 +514,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -488,6 +553,7 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * @param body Input number as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;BigDecimal&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -496,10 +562,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
+        return fakeOuterNumberSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -515,13 +585,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, Map<String, String> headers, final ApiCallback<BigDecimal> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterStringSerialize
      * @param body Input string as post body (optional)
@@ -534,7 +613,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeCall(String body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -569,14 +648,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -602,6 +687,7 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * @param body Input string as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -610,10 +696,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
+        return fakeOuterStringSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -629,13 +719,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeAsync(String body, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithFileSchema
      * @param body  (required)
@@ -648,7 +747,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -683,11 +782,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -695,7 +800,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -719,6 +824,7 @@ public class FakeApi {
      * 
      * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -727,9 +833,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null);
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
+        return testBodyWithFileSchemaWithHttpInfo(body, null);
     }
 
     /**
@@ -745,12 +855,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithQueryParams
      * @param query  (required)
@@ -764,7 +882,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -800,11 +918,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'query' is set
         if (query == null) {
@@ -817,7 +941,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, headers, _callback);
         return localVarCall;
 
     }
@@ -843,6 +967,7 @@ public class FakeApi {
      * 
      * @param query  (required)
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -851,9 +976,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null);
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
+        return testBodyWithQueryParamsWithHttpInfo(query, body, null);
     }
 
     /**
@@ -870,12 +999,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testClientModel
      * @param body client model (required)
@@ -888,7 +1025,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClientModelCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -923,11 +1060,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClientModelValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClientModelValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -935,7 +1078,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testClientModelCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -961,6 +1104,7 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -969,10 +1113,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
+        return testClientModelWithHttpInfo(body, null);
     }
 
     /**
@@ -988,13 +1136,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClientModelAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEndpointParameters
      * @param number None (required)
@@ -1021,7 +1178,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1112,11 +1269,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "http_basic_test" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'number' is set
         if (number == null) {
@@ -1139,7 +1302,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         return localVarCall;
 
     }
@@ -1190,6 +1353,7 @@ public class FakeApi {
      * @param dateTime None (optional)
      * @param password None (optional)
      * @param paramCallback None (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1199,9 +1363,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
+        return testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
     }
 
     /**
@@ -1231,12 +1399,20 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEnumParameters
      * @param enumHeaderStringArray Header parameter enum test (string array) (optional)
@@ -1257,7 +1433,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1306,14 +1482,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         return localVarCall;
 
     }
@@ -1352,6 +1534,7 @@ public class FakeApi {
      * @param enumQueryDouble Query parameter enum test (double) (optional)
      * @param enumFormStringArray Form parameter enum test (string array) (optional)
      * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1361,9 +1544,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
+        return testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
     }
 
     /**
@@ -1387,13 +1574,21 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
-    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+
+        public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
+    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1434,11 +1629,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'requiredStringGroup' is set
         if (requiredStringGroup == null) {
@@ -1456,23 +1657,35 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         return localVarCall;
 
     }
 
 
-    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, null);
         return localVarApiClient.execute(localVarCall);
     }
 
-    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
+        return testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    }
 
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 
     public class APItestGroupParametersRequest {
         private final Integer requiredStringGroup;
@@ -1530,7 +1743,7 @@ public class FakeApi {
          </table>
          */
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
         }
 
         /**
@@ -1604,7 +1817,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = param;
 
         // create path and map variables
@@ -1639,11 +1852,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1651,7 +1870,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, headers, _callback);
         return localVarCall;
 
     }
@@ -1675,6 +1894,7 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * @param param request body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1683,9 +1903,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null);
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
+        return testInlineAdditionalPropertiesWithHttpInfo(param, null);
     }
 
     /**
@@ -1701,12 +1925,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testJsonFormData
      * @param param field1 (required)
@@ -1720,7 +1952,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1763,11 +1995,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1780,7 +2018,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, headers, _callback);
         return localVarCall;
 
     }
@@ -1806,6 +2044,7 @@ public class FakeApi {
      * 
      * @param param field1 (required)
      * @param param2 field2 (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1814,9 +2053,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null);
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
+        return testJsonFormDataWithHttpInfo(param, param2, null);
     }
 
     /**
@@ -1833,12 +2076,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataAsync(String param, String param2, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testQueryParameterCollectionFormat
      * @param pipe  (required)
@@ -1855,7 +2106,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1895,11 +2146,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'pipe' is set
         if (pipe == null) {
@@ -1927,7 +2184,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, headers, _callback);
         return localVarCall;
 
     }
@@ -1959,6 +2216,7 @@ public class FakeApi {
      * @param http  (required)
      * @param url  (required)
      * @param context  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1967,9 +2225,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null);
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        return testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
     }
 
     /**
@@ -1989,10 +2251,18 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -69,7 +69,7 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClassnameCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -104,11 +104,17 @@ public class FakeClassnameTags123Api {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key_query" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClassnameValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClassnameValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -116,7 +122,7 @@ public class FakeClassnameTags123Api {
         }
         
 
-        okhttp3.Call localVarCall = testClassnameCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -142,6 +148,7 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -150,10 +157,14 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
+        return testClassnameWithHttpInfo(body, null);
     }
 
     /**
@@ -169,11 +180,20 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClassnameAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -140,7 +140,11 @@ public class FakeClassnameTags123Api {
      </table>
      */
     public Client testClassname(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClassname(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
@@ -144,7 +144,12 @@ public class PetApi {
      </table>
      */
     public void addPet(Pet body) throws ApiException {
-        addPetWithHttpInfo(body);
+        addPetWithHttpInfo(body, null);
+        
+    }
+    public void addPet(Pet body, Map<String, String> headers) throws ApiException {
+      addPetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -286,7 +291,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deletePet(Long petId, String apiKey) throws ApiException {
-        deletePetWithHttpInfo(petId, apiKey);
+        deletePetWithHttpInfo(petId, apiKey, null);
+        
+    }
+    public void deletePet(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+      deletePetWithHttpInfo(petId, apiKey, headers);
+        
     }
 
     /**
@@ -428,7 +438,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
-        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status);
+        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, null);
+        return localVarResp.getData();
+    }
+    public List<Pet> findPetsByStatus(List<String> status, Map<String, String> headers) throws ApiException {
+      ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, headers);
         return localVarResp.getData();
     }
 
@@ -577,7 +591,11 @@ Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
      */
     @Deprecated
     public Set<Pet> findPetsByTags(Set<String> tags) throws ApiException {
-        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags);
+        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, null);
+        return localVarResp.getData();
+    }
+    public Set<Pet> findPetsByTags(Set<String> tags, Map<String, String> headers) throws ApiException {
+      ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, headers);
         return localVarResp.getData();
     }
 
@@ -728,7 +746,11 @@ Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
      </table>
      */
     public Pet getPetById(Long petId) throws ApiException {
-        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId);
+        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, null);
+        return localVarResp.getData();
+    }
+    public Pet getPetById(Long petId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, headers);
         return localVarResp.getData();
     }
 
@@ -876,7 +898,12 @@ Type localVarReturnType = new TypeToken<Pet>(){}.getType();
      </table>
      */
     public void updatePet(Pet body) throws ApiException {
-        updatePetWithHttpInfo(body);
+        updatePetWithHttpInfo(body, null);
+        
+    }
+    public void updatePet(Pet body, Map<String, String> headers) throws ApiException {
+      updatePetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -1029,7 +1056,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
-        updatePetWithFormWithHttpInfo(petId, name, status);
+        updatePetWithFormWithHttpInfo(petId, name, status, null);
+        
+    }
+    public void updatePetWithForm(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+      updatePetWithFormWithHttpInfo(petId, name, status, headers);
+        
     }
 
     /**
@@ -1181,7 +1213,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, headers);
         return localVarResp.getData();
     }
 
@@ -1342,7 +1378,11 @@ Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
      </table>
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/PetApi.java
@@ -73,7 +73,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call addPetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -108,11 +108,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call addPetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call addPetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -120,7 +126,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = addPetCall(body, _callback);
+        okhttp3.Call localVarCall = addPetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -145,6 +151,7 @@ public class PetApi {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -154,9 +161,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null);
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
+        return addPetWithHttpInfo(body, null);
     }
 
     /**
@@ -173,12 +184,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call addPetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deletePet
      * @param petId Pet id to delete (required)
@@ -193,7 +212,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deletePetCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -230,11 +249,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -242,7 +267,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, headers, _callback);
         return localVarCall;
 
     }
@@ -269,6 +294,7 @@ public class PetApi {
      * 
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -278,9 +304,13 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null);
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
+        return deletePetWithHttpInfo(petId, apiKey, null);
     }
 
     /**
@@ -298,12 +328,20 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deletePetAsync(Long petId, String apiKey, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByStatus
      * @param status Status values that need to be considered for filter (required)
@@ -317,7 +355,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -353,11 +391,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'status' is set
         if (status == null) {
@@ -365,7 +409,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByStatusCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusCall(status, headers, _callback);
         return localVarCall;
 
     }
@@ -392,6 +436,7 @@ public class PetApi {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -401,10 +446,14 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, null);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
+        return findPetsByStatusWithHttpInfo(status, null);
     }
 
     /**
@@ -421,13 +470,22 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusAsync(List<String> status, Map<String, String> headers, final ApiCallback<List<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, _callback);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null, _callback);
+Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByTags
      * @param tags Tags to filter by (required)
@@ -443,7 +501,7 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -479,12 +537,18 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @Deprecated
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'tags' is set
         if (tags == null) {
@@ -492,7 +556,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByTagsCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsCall(tags, headers, _callback);
         return localVarCall;
 
     }
@@ -521,6 +585,7 @@ public class PetApi {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Set&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -532,10 +597,14 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, null);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
+        return findPetsByTagsWithHttpInfo(tags, null);
     }
 
     /**
@@ -554,13 +623,23 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, Map<String, String> headers, final ApiCallback<Set<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, _callback);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+            @Deprecated
+        public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null, _callback);
+Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getPetById
      * @param petId ID of pet to return (required)
@@ -575,7 +654,7 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdCall(Long petId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getPetByIdCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -611,11 +690,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -623,7 +708,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = getPetByIdCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdCall(petId, headers, _callback);
         return localVarCall;
 
     }
@@ -651,6 +736,7 @@ public class PetApi {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Pet&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -661,10 +747,14 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, null);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
+        return getPetByIdWithHttpInfo(petId, null);
     }
 
     /**
@@ -682,13 +772,22 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+    public okhttp3.Call getPetByIdAsync(Long petId, Map<String, String> headers, final ApiCallback<Pet> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, _callback);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null, _callback);
+Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePet
      * @param body Pet object that needs to be added to the store (required)
@@ -704,7 +803,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -739,11 +838,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -751,7 +856,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -778,6 +883,7 @@ public class PetApi {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -789,9 +895,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null);
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
+        return updatePetWithHttpInfo(body, null);
     }
 
     /**
@@ -810,12 +920,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePetWithForm
      * @param petId ID of pet that needs to be updated (required)
@@ -830,7 +948,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -874,11 +992,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -886,7 +1010,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, headers, _callback);
         return localVarCall;
 
     }
@@ -914,6 +1038,7 @@ public class PetApi {
      * @param petId ID of pet that needs to be updated (required)
      * @param name Updated name of the pet (optional)
      * @param status Updated status of the pet (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -922,9 +1047,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null);
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
+        return updatePetWithFormWithHttpInfo(petId, name, status, null);
     }
 
     /**
@@ -942,12 +1071,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFile
      * @param petId ID of pet to update (required)
@@ -962,7 +1099,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1006,11 +1143,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -1018,7 +1161,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, headers, _callback);
         return localVarCall;
 
     }
@@ -1048,6 +1191,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param additionalMetadata Additional data to pass to server (optional)
      * @param file file to upload (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1056,10 +1200,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
+        return uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
     }
 
     /**
@@ -1077,13 +1225,22 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFileWithRequiredFile
      * @param petId ID of pet to update (required)
@@ -1098,7 +1255,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1142,11 +1299,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -1159,7 +1322,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, headers, _callback);
         return localVarCall;
 
     }
@@ -1189,6 +1352,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param requiredFile file to upload (required)
      * @param additionalMetadata Additional data to pass to server (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1197,10 +1361,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
+        return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
     }
 
     /**
@@ -1218,11 +1386,20 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -142,7 +142,12 @@ public class StoreApi {
      </table>
      */
     public void deleteOrder(String orderId) throws ApiException {
-        deleteOrderWithHttpInfo(orderId);
+        deleteOrderWithHttpInfo(orderId, null);
+        
+    }
+    public void deleteOrder(String orderId, Map<String, String> headers) throws ApiException {
+      deleteOrderWithHttpInfo(orderId, headers);
+        
     }
 
     /**
@@ -272,7 +277,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Map<String, Integer> getInventory() throws ApiException {
-        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo();
+        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(null);
+        return localVarResp.getData();
+    }
+    public Map<String, Integer> getInventory(Map<String, String> headers) throws ApiException {
+      ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(headers);
         return localVarResp.getData();
     }
 
@@ -414,7 +423,11 @@ Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
      </table>
      */
     public Order getOrderById(Long orderId) throws ApiException {
-        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId);
+        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, null);
+        return localVarResp.getData();
+    }
+    public Order getOrderById(Long orderId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, headers);
         return localVarResp.getData();
     }
 
@@ -559,7 +572,11 @@ Type localVarReturnType = new TypeToken<Order>(){}.getType();
      </table>
      */
     public Order placeOrder(Order body) throws ApiException {
-        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body);
+        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Order placeOrder(Order body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -70,7 +70,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderCall(String orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteOrderCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -106,11 +106,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -118,7 +124,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteOrderCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -143,6 +149,7 @@ public class StoreApi {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -152,9 +159,13 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null);
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
+        return deleteOrderWithHttpInfo(orderId, null);
     }
 
     /**
@@ -171,12 +182,20 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteOrderAsync(String orderId, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getInventory
      * @param _callback Callback for upload/download progress
@@ -188,7 +207,7 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getInventoryCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -223,14 +242,20 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getInventoryValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getInventoryValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = getInventoryCall(_callback);
+        okhttp3.Call localVarCall = getInventoryCall(headers, _callback);
         return localVarCall;
 
     }
@@ -254,6 +279,7 @@ public class StoreApi {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -262,10 +288,14 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, null);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
+        return getInventoryWithHttpInfo(null);
     }
 
     /**
@@ -280,13 +310,22 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+    public okhttp3.Call getInventoryAsync(Map<String, String> headers, final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, _callback);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null, _callback);
+Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getOrderById
      * @param orderId ID of pet that needs to be fetched (required)
@@ -301,7 +340,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -337,11 +376,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -349,7 +394,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = getOrderByIdCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -377,6 +422,7 @@ public class StoreApi {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -387,10 +433,14 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
+        return getOrderByIdWithHttpInfo(orderId, null);
     }
 
     /**
@@ -408,13 +458,22 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdAsync(Long orderId, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for placeOrder
      * @param body order placed for purchasing the pet (required)
@@ -428,7 +487,7 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderCall(Order body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call placeOrderCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -463,11 +522,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call placeOrderValidateBeforeCall(Order body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call placeOrderValidateBeforeCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -475,7 +540,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = placeOrderCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -502,6 +567,7 @@ public class StoreApi {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -511,10 +577,14 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null);
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
+        return placeOrderWithHttpInfo(body, null);
     }
 
     /**
@@ -531,11 +601,20 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call placeOrderAsync(Order body, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
@@ -139,7 +139,12 @@ public class UserApi {
      </table>
      */
     public void createUser(User body) throws ApiException {
-        createUserWithHttpInfo(body);
+        createUserWithHttpInfo(body, null);
+        
+    }
+    public void createUser(User body, Map<String, String> headers) throws ApiException {
+      createUserWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -273,7 +278,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithArrayInput(List<User> body) throws ApiException {
-        createUsersWithArrayInputWithHttpInfo(body);
+        createUsersWithArrayInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithArrayInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithArrayInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -407,7 +417,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithListInput(List<User> body) throws ApiException {
-        createUsersWithListInputWithHttpInfo(body);
+        createUsersWithListInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithListInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithListInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -544,7 +559,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deleteUser(String username) throws ApiException {
-        deleteUserWithHttpInfo(username);
+        deleteUserWithHttpInfo(username, null);
+        
+    }
+    public void deleteUser(String username, Map<String, String> headers) throws ApiException {
+      deleteUserWithHttpInfo(username, headers);
+        
     }
 
     /**
@@ -686,7 +706,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public User getUserByName(String username) throws ApiException {
-        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username);
+        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, null);
+        return localVarResp.getData();
+    }
+    public User getUserByName(String username, Map<String, String> headers) throws ApiException {
+      ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, headers);
         return localVarResp.getData();
     }
 
@@ -840,7 +864,11 @@ Type localVarReturnType = new TypeToken<User>(){}.getType();
      </table>
      */
     public String loginUser(String username, String password) throws ApiException {
-        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password);
+        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, null);
+        return localVarResp.getData();
+    }
+    public String loginUser(String username, String password, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, headers);
         return localVarResp.getData();
     }
 
@@ -975,7 +1003,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void logoutUser() throws ApiException {
-        logoutUserWithHttpInfo();
+        logoutUserWithHttpInfo(null);
+        
+    }
+    public void logoutUser(Map<String, String> headers) throws ApiException {
+      logoutUserWithHttpInfo(headers);
+        
     }
 
     /**
@@ -1117,7 +1150,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updateUser(String username, User body) throws ApiException {
-        updateUserWithHttpInfo(username, body);
+        updateUserWithHttpInfo(username, body, null);
+        
+    }
+    public void updateUser(String username, User body, Map<String, String> headers) throws ApiException {
+      updateUserWithHttpInfo(username, body, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/api/UserApi.java
@@ -69,7 +69,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserCall(User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUserCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -104,11 +104,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUserValidateBeforeCall(User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUserValidateBeforeCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -116,7 +122,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUserCall(body, _callback);
+        okhttp3.Call localVarCall = createUserCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -140,6 +146,7 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -148,9 +155,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUserWithHttpInfo(User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
+        return createUserWithHttpInfo(body, null);
     }
 
     /**
@@ -166,12 +177,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUserAsync(User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithArrayInput
      * @param body List of user object (required)
@@ -184,7 +203,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -219,11 +238,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -231,7 +256,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -255,6 +280,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -263,9 +289,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithArrayInputWithHttpInfo(body, null);
     }
 
     /**
@@ -281,12 +311,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithListInput
      * @param body List of user object (required)
@@ -299,7 +337,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -334,11 +372,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -346,7 +390,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithListInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -370,6 +414,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -378,9 +423,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithListInputWithHttpInfo(body, null);
     }
 
     /**
@@ -396,12 +445,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deleteUser
      * @param username The name that needs to be deleted (required)
@@ -415,7 +472,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteUserCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -451,11 +508,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteUserValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteUserValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -463,7 +526,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteUserCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -488,6 +551,7 @@ public class UserApi {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -497,9 +561,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null);
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
+        return deleteUserWithHttpInfo(username, null);
     }
 
     /**
@@ -516,12 +584,20 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteUserAsync(String username, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getUserByName
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
@@ -536,7 +612,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getUserByNameCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -572,11 +648,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getUserByNameValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getUserByNameValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -584,7 +666,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = getUserByNameCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -612,6 +694,7 @@ public class UserApi {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;User&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -622,10 +705,14 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, null);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
+        return getUserByNameWithHttpInfo(username, null);
     }
 
     /**
@@ -643,13 +730,22 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+    public okhttp3.Call getUserByNameAsync(String username, Map<String, String> headers, final ApiCallback<User> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, _callback);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null, _callback);
+Type localVarReturnType = new TypeToken<User>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for loginUser
      * @param username The user name for login (required)
@@ -664,7 +760,7 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call loginUserCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -701,11 +797,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -718,7 +820,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = loginUserCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserCall(username, password, headers, _callback);
         return localVarCall;
 
     }
@@ -747,6 +849,7 @@ public class UserApi {
      * 
      * @param username The user name for login (required)
      * @param password The password for login in clear text (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -756,10 +859,14 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
+        return loginUserWithHttpInfo(username, password, null);
     }
 
     /**
@@ -777,13 +884,22 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call loginUserAsync(String username, String password, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for logoutUser
      * @param _callback Callback for upload/download progress
@@ -795,7 +911,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logoutUserCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -830,14 +946,20 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logoutUserValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logoutUserValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = logoutUserCall(_callback);
+        okhttp3.Call localVarCall = logoutUserCall(headers, _callback);
         return localVarCall;
 
     }
@@ -859,6 +981,7 @@ public class UserApi {
     /**
      * Logs out current logged in user session
      * 
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -867,9 +990,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null);
+    public ApiResponse<Void> logoutUserWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
+        return logoutUserWithHttpInfo(null);
     }
 
     /**
@@ -884,12 +1011,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call logoutUserAsync(Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updateUser
      * @param username name that need to be deleted (required)
@@ -904,7 +1039,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updateUserCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -940,11 +1075,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, apiOperation.getMethod(), localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -957,7 +1098,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = updateUserCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserCall(username, body, headers, _callback);
         return localVarCall;
 
     }
@@ -984,6 +1125,7 @@ public class UserApi {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted (required)
      * @param body Updated user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -993,9 +1135,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null);
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
+        return updateUserWithHttpInfo(username, body, null);
     }
 
     /**
@@ -1013,10 +1159,18 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updateUserAsync(String username, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -1110,13 +1110,12 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP call
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, callback);
 
         return httpClient.newCall(request);
     }
@@ -1132,13 +1131,11 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
-    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
+    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
 
         final String url = buildUrl(path, queryParams, collectionQueryParams);
         final Request.Builder reqBuilder = new Request.Builder().url(url);

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -129,7 +129,11 @@ public class AnotherFakeApi {
      </table>
      */
     public Client call123testSpecialTags(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client call123testSpecialTags(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -66,7 +66,7 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class AnotherFakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class AnotherFakeApi {
         }
         
 
-        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -131,6 +137,7 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -139,10 +146,14 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null);
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
+        return call123testSpecialTagsWithHttpInfo(body, null);
     }
 
     /**
@@ -158,11 +169,20 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -136,7 +136,12 @@ public class FakeApi {
      </table>
      */
     public void createXmlItem(XmlItem xmlItem) throws ApiException {
-        createXmlItemWithHttpInfo(xmlItem);
+        createXmlItemWithHttpInfo(xmlItem, null);
+        
+    }
+    public void createXmlItem(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+      createXmlItemWithHttpInfo(xmlItem, headers);
+        
     }
 
     /**
@@ -258,7 +263,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
-        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body);
+        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Boolean fakeOuterBooleanSerialize(Boolean body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -384,7 +393,11 @@ Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
      </table>
      */
     public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
-        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body);
+        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public OuterComposite fakeOuterCompositeSerialize(OuterComposite body, Map<String, String> headers) throws ApiException {
+      ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -510,7 +523,11 @@ Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
      </table>
      */
     public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
-        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body);
+        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public BigDecimal fakeOuterNumberSerialize(BigDecimal body, Map<String, String> headers) throws ApiException {
+      ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -636,7 +653,11 @@ Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
      </table>
      */
     public String fakeOuterStringSerialize(String body) throws ApiException {
-        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body);
+        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public String fakeOuterStringSerialize(String body, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -766,7 +787,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
-        testBodyWithFileSchemaWithHttpInfo(body);
+        testBodyWithFileSchemaWithHttpInfo(body, null);
+        
+    }
+    public void testBodyWithFileSchema(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+      testBodyWithFileSchemaWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -903,7 +929,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testBodyWithQueryParams(String query, User body) throws ApiException {
-        testBodyWithQueryParamsWithHttpInfo(query, body);
+        testBodyWithQueryParamsWithHttpInfo(query, body, null);
+        
+    }
+    public void testBodyWithQueryParams(String query, User body, Map<String, String> headers) throws ApiException {
+      testBodyWithQueryParamsWithHttpInfo(query, body, headers);
+        
     }
 
     /**
@@ -1032,7 +1063,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Client testClientModel(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClientModel(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -1261,7 +1296,12 @@ Type localVarReturnType = new TypeToken<Client>(){}.getType();
      </table>
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+        
+    }
+    public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+      testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers);
+        
     }
 
     /**
@@ -1458,7 +1498,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+        
+    }
+    public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+      testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers);
+        
     }
 
     /**
@@ -1827,7 +1872,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
-        testInlineAdditionalPropertiesWithHttpInfo(param);
+        testInlineAdditionalPropertiesWithHttpInfo(param, null);
+        
+    }
+    public void testInlineAdditionalProperties(Map<String, String> param, Map<String, String> headers) throws ApiException {
+      testInlineAdditionalPropertiesWithHttpInfo(param, headers);
+        
     }
 
     /**
@@ -1968,7 +2018,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testJsonFormData(String param, String param2) throws ApiException {
-        testJsonFormDataWithHttpInfo(param, param2);
+        testJsonFormDataWithHttpInfo(param, param2, null);
+        
+    }
+    public void testJsonFormData(String param, String param2, Map<String, String> headers) throws ApiException {
+      testJsonFormDataWithHttpInfo(param, param2, headers);
+        
     }
 
     /**
@@ -2144,7 +2199,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
+        
+    }
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+      testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -74,7 +74,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = xmlItem;
 
         // create path and map variables
@@ -101,11 +101,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'xmlItem' is set
         if (xmlItem == null) {
@@ -113,7 +119,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, headers, _callback);
         return localVarCall;
 
     }
@@ -137,6 +143,7 @@ public class FakeApi {
      * creates an XmlItem
      * this route creates an XmlItem
      * @param xmlItem XmlItem Body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -145,9 +152,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null);
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
+        return createXmlItemWithHttpInfo(xmlItem, null);
     }
 
     /**
@@ -163,12 +174,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterBooleanSerialize
      * @param body Input boolean as post body (optional)
@@ -181,7 +200,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -208,14 +227,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -241,6 +266,7 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * @param body Input boolean as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Boolean&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -249,10 +275,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
+        return fakeOuterBooleanSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -268,13 +298,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, Map<String, String> headers, final ApiCallback<Boolean> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterCompositeSerialize
      * @param body Input composite as post body (optional)
@@ -287,7 +326,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -314,14 +353,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -347,6 +392,7 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * @param body Input composite as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;OuterComposite&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -355,10 +401,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null);
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
+        return fakeOuterCompositeSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -374,13 +424,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, Map<String, String> headers, final ApiCallback<OuterComposite> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterNumberSerialize
      * @param body Input number as post body (optional)
@@ -393,7 +452,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -420,14 +479,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -453,6 +518,7 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * @param body Input number as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;BigDecimal&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -461,10 +527,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
+        return fakeOuterNumberSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -480,13 +550,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, Map<String, String> headers, final ApiCallback<BigDecimal> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterStringSerialize
      * @param body Input string as post body (optional)
@@ -499,7 +578,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeCall(String body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -526,14 +605,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -559,6 +644,7 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * @param body Input string as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -567,10 +653,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
+        return fakeOuterStringSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -586,13 +676,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeAsync(String body, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithFileSchema
      * @param body  (required)
@@ -605,7 +704,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -632,11 +731,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -644,7 +749,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -668,6 +773,7 @@ public class FakeApi {
      * 
      * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -676,9 +782,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null);
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
+        return testBodyWithFileSchemaWithHttpInfo(body, null);
     }
 
     /**
@@ -694,12 +804,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithQueryParams
      * @param query  (required)
@@ -713,7 +831,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -744,11 +862,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'query' is set
         if (query == null) {
@@ -761,7 +885,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, headers, _callback);
         return localVarCall;
 
     }
@@ -787,6 +911,7 @@ public class FakeApi {
      * 
      * @param query  (required)
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -795,9 +920,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null);
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
+        return testBodyWithQueryParamsWithHttpInfo(query, body, null);
     }
 
     /**
@@ -814,12 +943,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testClientModel
      * @param body client model (required)
@@ -832,7 +969,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClientModelCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -859,11 +996,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClientModelValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClientModelValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -871,7 +1014,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testClientModelCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -897,6 +1040,7 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -905,10 +1049,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
+        return testClientModelWithHttpInfo(body, null);
     }
 
     /**
@@ -924,13 +1072,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClientModelAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEndpointParameters
      * @param number None (required)
@@ -957,7 +1114,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1040,11 +1197,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "http_basic_test" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'number' is set
         if (number == null) {
@@ -1067,7 +1230,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         return localVarCall;
 
     }
@@ -1118,6 +1281,7 @@ public class FakeApi {
      * @param dateTime None (optional)
      * @param password None (optional)
      * @param paramCallback None (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1127,9 +1291,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
+        return testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
     }
 
     /**
@@ -1159,12 +1327,20 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEnumParameters
      * @param enumHeaderStringArray Header parameter enum test (string array) (optional)
@@ -1185,7 +1361,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1244,14 +1420,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         return localVarCall;
 
     }
@@ -1290,6 +1472,7 @@ public class FakeApi {
      * @param enumQueryDouble Query parameter enum test (double) (optional)
      * @param enumFormStringArray Form parameter enum test (string array) (optional)
      * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1299,9 +1482,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
+        return testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
     }
 
     /**
@@ -1325,13 +1512,21 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
-    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+
+        public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
+    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1382,11 +1577,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'requiredStringGroup' is set
         if (requiredStringGroup == null) {
@@ -1404,23 +1605,35 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         return localVarCall;
 
     }
 
 
-    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, null);
         return localVarApiClient.execute(localVarCall);
     }
 
-    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
+        return testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    }
 
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 
     public class APItestGroupParametersRequest {
         private final Integer requiredStringGroup;
@@ -1478,7 +1691,7 @@ public class FakeApi {
          </table>
          */
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
         }
 
         /**
@@ -1552,7 +1765,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = param;
 
         // create path and map variables
@@ -1579,11 +1792,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1591,7 +1810,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, headers, _callback);
         return localVarCall;
 
     }
@@ -1615,6 +1834,7 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * @param param request body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1623,9 +1843,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null);
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
+        return testInlineAdditionalPropertiesWithHttpInfo(param, null);
     }
 
     /**
@@ -1641,12 +1865,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testJsonFormData
      * @param param field1 (required)
@@ -1660,7 +1892,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1695,11 +1927,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1712,7 +1950,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, headers, _callback);
         return localVarCall;
 
     }
@@ -1738,6 +1976,7 @@ public class FakeApi {
      * 
      * @param param field1 (required)
      * @param param2 field2 (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1746,9 +1985,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null);
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
+        return testJsonFormDataWithHttpInfo(param, param2, null);
     }
 
     /**
@@ -1765,12 +2008,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataAsync(String param, String param2, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testQueryParameterCollectionFormat
      * @param pipe  (required)
@@ -1787,7 +2038,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1834,11 +2085,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'pipe' is set
         if (pipe == null) {
@@ -1866,7 +2123,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, headers, _callback);
         return localVarCall;
 
     }
@@ -1898,6 +2155,7 @@ public class FakeApi {
      * @param http  (required)
      * @param url  (required)
      * @param context  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1906,9 +2164,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null);
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        return testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
     }
 
     /**
@@ -1928,10 +2190,18 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -66,7 +66,7 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClassnameCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class FakeClassnameTags123Api {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key_query" };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClassnameValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClassnameValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class FakeClassnameTags123Api {
         }
         
 
-        okhttp3.Call localVarCall = testClassnameCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -131,6 +137,7 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -139,10 +146,14 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
+        return testClassnameWithHttpInfo(body, null);
     }
 
     /**
@@ -158,11 +169,20 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClassnameAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -129,7 +129,11 @@ public class FakeClassnameTags123Api {
      </table>
      */
     public Client testClassname(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClassname(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
@@ -70,7 +70,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call addPetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -97,11 +97,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call addPetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call addPetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -109,7 +115,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = addPetCall(body, _callback);
+        okhttp3.Call localVarCall = addPetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -134,6 +140,7 @@ public class PetApi {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -143,9 +150,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null);
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
+        return addPetWithHttpInfo(body, null);
     }
 
     /**
@@ -162,12 +173,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call addPetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deletePet
      * @param petId Pet id to delete (required)
@@ -182,7 +201,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deletePetCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -214,11 +233,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -226,7 +251,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, headers, _callback);
         return localVarCall;
 
     }
@@ -253,6 +278,7 @@ public class PetApi {
      * 
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -262,9 +288,13 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null);
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
+        return deletePetWithHttpInfo(petId, apiKey, null);
     }
 
     /**
@@ -282,12 +312,20 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deletePetAsync(Long petId, String apiKey, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByStatus
      * @param status Status values that need to be considered for filter (required)
@@ -301,7 +339,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -332,11 +370,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'status' is set
         if (status == null) {
@@ -344,7 +388,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByStatusCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusCall(status, headers, _callback);
         return localVarCall;
 
     }
@@ -371,6 +415,7 @@ public class PetApi {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -380,10 +425,14 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, null);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
+        return findPetsByStatusWithHttpInfo(status, null);
     }
 
     /**
@@ -400,13 +449,22 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusAsync(List<String> status, Map<String, String> headers, final ApiCallback<List<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, _callback);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null, _callback);
+Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByTags
      * @param tags Tags to filter by (required)
@@ -422,7 +480,7 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -453,12 +511,18 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @Deprecated
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'tags' is set
         if (tags == null) {
@@ -466,7 +530,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByTagsCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsCall(tags, headers, _callback);
         return localVarCall;
 
     }
@@ -495,6 +559,7 @@ public class PetApi {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Set&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -506,10 +571,14 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, null);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
+        return findPetsByTagsWithHttpInfo(tags, null);
     }
 
     /**
@@ -528,13 +597,23 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, Map<String, String> headers, final ApiCallback<Set<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, _callback);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+            @Deprecated
+        public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null, _callback);
+Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getPetById
      * @param petId ID of pet to return (required)
@@ -549,7 +628,7 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdCall(Long petId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getPetByIdCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -577,11 +656,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -589,7 +674,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = getPetByIdCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdCall(petId, headers, _callback);
         return localVarCall;
 
     }
@@ -617,6 +702,7 @@ public class PetApi {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Pet&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -627,10 +713,14 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, null);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
+        return getPetByIdWithHttpInfo(petId, null);
     }
 
     /**
@@ -648,13 +738,22 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+    public okhttp3.Call getPetByIdAsync(Long petId, Map<String, String> headers, final ApiCallback<Pet> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, _callback);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null, _callback);
+Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePet
      * @param body Pet object that needs to be added to the store (required)
@@ -670,7 +769,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -697,11 +796,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -709,7 +814,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -736,6 +841,7 @@ public class PetApi {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -747,9 +853,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null);
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
+        return updatePetWithHttpInfo(body, null);
     }
 
     /**
@@ -768,12 +878,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePetWithForm
      * @param petId ID of pet that needs to be updated (required)
@@ -788,7 +906,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -824,11 +942,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -836,7 +960,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, headers, _callback);
         return localVarCall;
 
     }
@@ -864,6 +988,7 @@ public class PetApi {
      * @param petId ID of pet that needs to be updated (required)
      * @param name Updated name of the pet (optional)
      * @param status Updated status of the pet (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -872,9 +997,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null);
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
+        return updatePetWithFormWithHttpInfo(petId, name, status, null);
     }
 
     /**
@@ -892,12 +1021,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFile
      * @param petId ID of pet to update (required)
@@ -912,7 +1049,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -948,11 +1085,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -960,7 +1103,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, headers, _callback);
         return localVarCall;
 
     }
@@ -990,6 +1133,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param additionalMetadata Additional data to pass to server (optional)
      * @param file file to upload (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -998,10 +1142,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
+        return uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
     }
 
     /**
@@ -1019,13 +1167,22 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFileWithRequiredFile
      * @param petId ID of pet to update (required)
@@ -1040,7 +1197,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1076,11 +1233,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -1093,7 +1256,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, headers, _callback);
         return localVarCall;
 
     }
@@ -1123,6 +1286,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param requiredFile file to upload (required)
      * @param additionalMetadata Additional data to pass to server (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1131,10 +1295,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
+        return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
     }
 
     /**
@@ -1152,11 +1320,20 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/PetApi.java
@@ -133,7 +133,12 @@ public class PetApi {
      </table>
      */
     public void addPet(Pet body) throws ApiException {
-        addPetWithHttpInfo(body);
+        addPetWithHttpInfo(body, null);
+        
+    }
+    public void addPet(Pet body, Map<String, String> headers) throws ApiException {
+      addPetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -270,7 +275,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deletePet(Long petId, String apiKey) throws ApiException {
-        deletePetWithHttpInfo(petId, apiKey);
+        deletePetWithHttpInfo(petId, apiKey, null);
+        
+    }
+    public void deletePet(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+      deletePetWithHttpInfo(petId, apiKey, headers);
+        
     }
 
     /**
@@ -407,7 +417,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
-        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status);
+        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, null);
+        return localVarResp.getData();
+    }
+    public List<Pet> findPetsByStatus(List<String> status, Map<String, String> headers) throws ApiException {
+      ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, headers);
         return localVarResp.getData();
     }
 
@@ -551,7 +565,11 @@ Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
      */
     @Deprecated
     public Set<Pet> findPetsByTags(Set<String> tags) throws ApiException {
-        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags);
+        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, null);
+        return localVarResp.getData();
+    }
+    public Set<Pet> findPetsByTags(Set<String> tags, Map<String, String> headers) throws ApiException {
+      ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, headers);
         return localVarResp.getData();
     }
 
@@ -694,7 +712,11 @@ Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
      </table>
      */
     public Pet getPetById(Long petId) throws ApiException {
-        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId);
+        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, null);
+        return localVarResp.getData();
+    }
+    public Pet getPetById(Long petId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, headers);
         return localVarResp.getData();
     }
 
@@ -834,7 +856,12 @@ Type localVarReturnType = new TypeToken<Pet>(){}.getType();
      </table>
      */
     public void updatePet(Pet body) throws ApiException {
-        updatePetWithHttpInfo(body);
+        updatePetWithHttpInfo(body, null);
+        
+    }
+    public void updatePet(Pet body, Map<String, String> headers) throws ApiException {
+      updatePetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -979,7 +1006,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
-        updatePetWithFormWithHttpInfo(petId, name, status);
+        updatePetWithFormWithHttpInfo(petId, name, status, null);
+        
+    }
+    public void updatePetWithForm(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+      updatePetWithFormWithHttpInfo(petId, name, status, headers);
+        
     }
 
     /**
@@ -1123,7 +1155,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, headers);
         return localVarResp.getData();
     }
 
@@ -1276,7 +1312,11 @@ Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
      </table>
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -131,7 +131,12 @@ public class StoreApi {
      </table>
      */
     public void deleteOrder(String orderId) throws ApiException {
-        deleteOrderWithHttpInfo(orderId);
+        deleteOrderWithHttpInfo(orderId, null);
+        
+    }
+    public void deleteOrder(String orderId, Map<String, String> headers) throws ApiException {
+      deleteOrderWithHttpInfo(orderId, headers);
+        
     }
 
     /**
@@ -253,7 +258,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Map<String, Integer> getInventory() throws ApiException {
-        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo();
+        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(null);
+        return localVarResp.getData();
+    }
+    public Map<String, Integer> getInventory(Map<String, String> headers) throws ApiException {
+      ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(headers);
         return localVarResp.getData();
     }
 
@@ -387,7 +396,11 @@ Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
      </table>
      */
     public Order getOrderById(Long orderId) throws ApiException {
-        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId);
+        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, null);
+        return localVarResp.getData();
+    }
+    public Order getOrderById(Long orderId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, headers);
         return localVarResp.getData();
     }
 
@@ -524,7 +537,11 @@ Type localVarReturnType = new TypeToken<Order>(){}.getType();
      </table>
      */
     public Order placeOrder(Order body) throws ApiException {
-        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body);
+        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Order placeOrder(Order body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -67,7 +67,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderCall(String orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteOrderCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -95,11 +95,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -107,7 +113,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteOrderCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -132,6 +138,7 @@ public class StoreApi {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -141,9 +148,13 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null);
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
+        return deleteOrderWithHttpInfo(orderId, null);
     }
 
     /**
@@ -160,12 +171,20 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteOrderAsync(String orderId, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getInventory
      * @param _callback Callback for upload/download progress
@@ -177,7 +196,7 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getInventoryCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -204,14 +223,20 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getInventoryValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getInventoryValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = getInventoryCall(_callback);
+        okhttp3.Call localVarCall = getInventoryCall(headers, _callback);
         return localVarCall;
 
     }
@@ -235,6 +260,7 @@ public class StoreApi {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -243,10 +269,14 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, null);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
+        return getInventoryWithHttpInfo(null);
     }
 
     /**
@@ -261,13 +291,22 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+    public okhttp3.Call getInventoryAsync(Map<String, String> headers, final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, _callback);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null, _callback);
+Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getOrderById
      * @param orderId ID of pet that needs to be fetched (required)
@@ -282,7 +321,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -310,11 +349,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -322,7 +367,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = getOrderByIdCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -350,6 +395,7 @@ public class StoreApi {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -360,10 +406,14 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
+        return getOrderByIdWithHttpInfo(orderId, null);
     }
 
     /**
@@ -381,13 +431,22 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdAsync(Long orderId, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for placeOrder
      * @param body order placed for purchasing the pet (required)
@@ -401,7 +460,7 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderCall(Order body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call placeOrderCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -428,11 +487,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call placeOrderValidateBeforeCall(Order body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call placeOrderValidateBeforeCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -440,7 +505,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = placeOrderCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -467,6 +532,7 @@ public class StoreApi {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -476,10 +542,14 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null);
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
+        return placeOrderWithHttpInfo(body, null);
     }
 
     /**
@@ -496,11 +566,20 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call placeOrderAsync(Order body, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserCall(User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUserCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUserValidateBeforeCall(User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUserValidateBeforeCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUserCall(body, _callback);
+        okhttp3.Call localVarCall = createUserCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -129,6 +135,7 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -137,9 +144,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUserWithHttpInfo(User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
+        return createUserWithHttpInfo(body, null);
     }
 
     /**
@@ -155,12 +166,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUserAsync(User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithArrayInput
      * @param body List of user object (required)
@@ -173,7 +192,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -200,11 +219,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -212,7 +237,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -236,6 +261,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -244,9 +270,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithArrayInputWithHttpInfo(body, null);
     }
 
     /**
@@ -262,12 +292,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithListInput
      * @param body List of user object (required)
@@ -280,7 +318,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -307,11 +345,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -319,7 +363,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithListInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -343,6 +387,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -351,9 +396,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithListInputWithHttpInfo(body, null);
     }
 
     /**
@@ -369,12 +418,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deleteUser
      * @param username The name that needs to be deleted (required)
@@ -388,7 +445,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteUserCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -416,11 +473,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteUserValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteUserValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -428,7 +491,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteUserCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -453,6 +516,7 @@ public class UserApi {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -462,9 +526,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null);
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
+        return deleteUserWithHttpInfo(username, null);
     }
 
     /**
@@ -481,12 +549,20 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteUserAsync(String username, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getUserByName
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
@@ -501,7 +577,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getUserByNameCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -529,11 +605,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getUserByNameValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getUserByNameValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -541,7 +623,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = getUserByNameCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -569,6 +651,7 @@ public class UserApi {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;User&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -579,10 +662,14 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, null);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
+        return getUserByNameWithHttpInfo(username, null);
     }
 
     /**
@@ -600,13 +687,22 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+    public okhttp3.Call getUserByNameAsync(String username, Map<String, String> headers, final ApiCallback<User> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, _callback);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null, _callback);
+Type localVarReturnType = new TypeToken<User>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for loginUser
      * @param username The user name for login (required)
@@ -621,7 +717,7 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call loginUserCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -656,11 +752,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -673,7 +775,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = loginUserCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserCall(username, password, headers, _callback);
         return localVarCall;
 
     }
@@ -702,6 +804,7 @@ public class UserApi {
      * 
      * @param username The user name for login (required)
      * @param password The password for login in clear text (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -711,10 +814,14 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
+        return loginUserWithHttpInfo(username, password, null);
     }
 
     /**
@@ -732,13 +839,22 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call loginUserAsync(String username, String password, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for logoutUser
      * @param _callback Callback for upload/download progress
@@ -750,7 +866,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logoutUserCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -777,14 +893,20 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logoutUserValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logoutUserValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = logoutUserCall(_callback);
+        okhttp3.Call localVarCall = logoutUserCall(headers, _callback);
         return localVarCall;
 
     }
@@ -806,6 +928,7 @@ public class UserApi {
     /**
      * Logs out current logged in user session
      * 
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -814,9 +937,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null);
+    public ApiResponse<Void> logoutUserWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
+        return logoutUserWithHttpInfo(null);
     }
 
     /**
@@ -831,12 +958,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call logoutUserAsync(Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updateUser
      * @param username name that need to be deleted (required)
@@ -851,7 +986,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updateUserCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -879,11 +1014,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -896,7 +1037,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = updateUserCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserCall(username, body, headers, _callback);
         return localVarCall;
 
     }
@@ -923,6 +1064,7 @@ public class UserApi {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted (required)
      * @param body Updated user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -932,9 +1074,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null);
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
+        return updateUserWithHttpInfo(username, body, null);
     }
 
     /**
@@ -952,10 +1098,18 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updateUserAsync(String username, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/UserApi.java
@@ -128,7 +128,12 @@ public class UserApi {
      </table>
      */
     public void createUser(User body) throws ApiException {
-        createUserWithHttpInfo(body);
+        createUserWithHttpInfo(body, null);
+        
+    }
+    public void createUser(User body, Map<String, String> headers) throws ApiException {
+      createUserWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -254,7 +259,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithArrayInput(List<User> body) throws ApiException {
-        createUsersWithArrayInputWithHttpInfo(body);
+        createUsersWithArrayInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithArrayInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithArrayInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -380,7 +390,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithListInput(List<User> body) throws ApiException {
-        createUsersWithListInputWithHttpInfo(body);
+        createUsersWithListInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithListInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithListInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -509,7 +524,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deleteUser(String username) throws ApiException {
-        deleteUserWithHttpInfo(username);
+        deleteUserWithHttpInfo(username, null);
+        
+    }
+    public void deleteUser(String username, Map<String, String> headers) throws ApiException {
+      deleteUserWithHttpInfo(username, headers);
+        
     }
 
     /**
@@ -643,7 +663,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public User getUserByName(String username) throws ApiException {
-        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username);
+        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, null);
+        return localVarResp.getData();
+    }
+    public User getUserByName(String username, Map<String, String> headers) throws ApiException {
+      ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, headers);
         return localVarResp.getData();
     }
 
@@ -795,7 +819,11 @@ Type localVarReturnType = new TypeToken<User>(){}.getType();
      </table>
      */
     public String loginUser(String username, String password) throws ApiException {
-        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password);
+        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, null);
+        return localVarResp.getData();
+    }
+    public String loginUser(String username, String password, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, headers);
         return localVarResp.getData();
     }
 
@@ -922,7 +950,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void logoutUser() throws ApiException {
-        logoutUserWithHttpInfo();
+        logoutUserWithHttpInfo(null);
+        
+    }
+    public void logoutUser(Map<String, String> headers) throws ApiException {
+      logoutUserWithHttpInfo(headers);
+        
     }
 
     /**
@@ -1056,7 +1089,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updateUser(String username, User body) throws ApiException {
-        updateUserWithHttpInfo(username, body);
+        updateUserWithHttpInfo(username, body, null);
+        
+    }
+    public void updateUser(String username, User body, Map<String, String> headers) throws ApiException {
+      updateUserWithHttpInfo(username, body, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -1110,13 +1110,12 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP call
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, authNames, callback);
+    public Call buildCall(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
+        Request request = buildRequest(path, method, queryParams, collectionQueryParams, body, headerParams, cookieParams, formParams, callback);
 
         return httpClient.newCall(request);
     }
@@ -1132,13 +1131,11 @@ public class ApiClient {
      * @param headerParams The header parameters
      * @param cookieParams The cookie parameters
      * @param formParams The form parameters
-     * @param authNames The authentications to apply
      * @param callback Callback for upload/download progress
      * @return The HTTP request
      * @throws ApiException If fail to serialize the request body object
      */
-    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String[] authNames, ApiCallback callback) throws ApiException {
-        updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
+    public Request buildRequest(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, ApiCallback callback) throws ApiException {
 
         final String url = buildUrl(path, queryParams, collectionQueryParams);
         final Request.Builder reqBuilder = new Request.Builder().url(url);

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -129,7 +129,11 @@ public class AnotherFakeApi {
      </table>
      */
     public Client call123testSpecialTags(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client call123testSpecialTags(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = call123testSpecialTagsWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -66,7 +66,7 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class AnotherFakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call call123testSpecialTagsValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class AnotherFakeApi {
         }
         
 
-        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -131,6 +137,7 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -139,10 +146,14 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null);
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
+        return call123testSpecialTagsWithHttpInfo(body, null);
     }
 
     /**
@@ -158,11 +169,20 @@ public class AnotherFakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call call123testSpecialTagsAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call call123testSpecialTagsAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = call123testSpecialTagsValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -136,7 +136,12 @@ public class FakeApi {
      </table>
      */
     public void createXmlItem(XmlItem xmlItem) throws ApiException {
-        createXmlItemWithHttpInfo(xmlItem);
+        createXmlItemWithHttpInfo(xmlItem, null);
+        
+    }
+    public void createXmlItem(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+      createXmlItemWithHttpInfo(xmlItem, headers);
+        
     }
 
     /**
@@ -258,7 +263,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
-        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body);
+        ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Boolean fakeOuterBooleanSerialize(Boolean body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Boolean> localVarResp = fakeOuterBooleanSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -384,7 +393,11 @@ Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
      </table>
      */
     public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
-        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body);
+        ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public OuterComposite fakeOuterCompositeSerialize(OuterComposite body, Map<String, String> headers) throws ApiException {
+      ApiResponse<OuterComposite> localVarResp = fakeOuterCompositeSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -510,7 +523,11 @@ Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
      </table>
      */
     public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
-        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body);
+        ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public BigDecimal fakeOuterNumberSerialize(BigDecimal body, Map<String, String> headers) throws ApiException {
+      ApiResponse<BigDecimal> localVarResp = fakeOuterNumberSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -636,7 +653,11 @@ Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
      </table>
      */
     public String fakeOuterStringSerialize(String body) throws ApiException {
-        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body);
+        ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public String fakeOuterStringSerialize(String body, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = fakeOuterStringSerializeWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -766,7 +787,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
-        testBodyWithFileSchemaWithHttpInfo(body);
+        testBodyWithFileSchemaWithHttpInfo(body, null);
+        
+    }
+    public void testBodyWithFileSchema(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+      testBodyWithFileSchemaWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -903,7 +929,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testBodyWithQueryParams(String query, User body) throws ApiException {
-        testBodyWithQueryParamsWithHttpInfo(query, body);
+        testBodyWithQueryParamsWithHttpInfo(query, body, null);
+        
+    }
+    public void testBodyWithQueryParams(String query, User body, Map<String, String> headers) throws ApiException {
+      testBodyWithQueryParamsWithHttpInfo(query, body, headers);
+        
     }
 
     /**
@@ -1032,7 +1063,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Client testClientModel(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClientModel(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClientModelWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 
@@ -1261,7 +1296,12 @@ Type localVarReturnType = new TypeToken<Client>(){}.getType();
      </table>
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+        
+    }
+    public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+      testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers);
+        
     }
 
     /**
@@ -1458,7 +1498,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+        
+    }
+    public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+      testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers);
+        
     }
 
     /**
@@ -1827,7 +1872,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
-        testInlineAdditionalPropertiesWithHttpInfo(param);
+        testInlineAdditionalPropertiesWithHttpInfo(param, null);
+        
+    }
+    public void testInlineAdditionalProperties(Map<String, String> param, Map<String, String> headers) throws ApiException {
+      testInlineAdditionalPropertiesWithHttpInfo(param, headers);
+        
     }
 
     /**
@@ -1968,7 +2018,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testJsonFormData(String param, String param2) throws ApiException {
-        testJsonFormDataWithHttpInfo(param, param2);
+        testJsonFormDataWithHttpInfo(param, param2, null);
+        
+    }
+    public void testJsonFormData(String param, String param2, Map<String, String> headers) throws ApiException {
+      testJsonFormDataWithHttpInfo(param, param2, headers);
+        
     }
 
     /**
@@ -2144,7 +2199,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
+        
+    }
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+      testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -74,7 +74,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createXmlItemCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = xmlItem;
 
         // create path and map variables
@@ -101,11 +101,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createXmlItemValidateBeforeCall(XmlItem xmlItem, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'xmlItem' is set
         if (xmlItem == null) {
@@ -113,7 +119,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemCall(xmlItem, headers, _callback);
         return localVarCall;
 
     }
@@ -137,6 +143,7 @@ public class FakeApi {
      * creates an XmlItem
      * this route creates an XmlItem
      * @param xmlItem XmlItem Body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -145,9 +152,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null);
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
+        return createXmlItemWithHttpInfo(xmlItem, null);
     }
 
     /**
@@ -163,12 +174,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, _callback);
+        okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createXmlItemAsync(XmlItem xmlItem, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createXmlItemValidateBeforeCall(xmlItem, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterBooleanSerialize
      * @param body Input boolean as post body (optional)
@@ -181,7 +200,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -208,14 +227,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterBooleanSerializeValidateBeforeCall(Boolean body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -241,6 +266,7 @@ public class FakeApi {
      * 
      * Test serialization of outer boolean types
      * @param body Input boolean as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Boolean&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -249,10 +275,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null);
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
+        return fakeOuterBooleanSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -268,13 +298,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, Map<String, String> headers, final ApiCallback<Boolean> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterBooleanSerializeAsync(Boolean body, final ApiCallback<Boolean> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterBooleanSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Boolean>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterCompositeSerialize
      * @param body Input composite as post body (optional)
@@ -287,7 +326,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -314,14 +353,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterCompositeSerializeValidateBeforeCall(OuterComposite body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -347,6 +392,7 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * @param body Input composite as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;OuterComposite&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -355,10 +401,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null);
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
+        return fakeOuterCompositeSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -374,13 +424,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, Map<String, String> headers, final ApiCallback<OuterComposite> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterCompositeSerializeAsync(OuterComposite body, final ApiCallback<OuterComposite> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterCompositeSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<OuterComposite>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterNumberSerialize
      * @param body Input number as post body (optional)
@@ -393,7 +452,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -420,14 +479,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterNumberSerializeValidateBeforeCall(BigDecimal body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -453,6 +518,7 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * @param body Input number as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;BigDecimal&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -461,10 +527,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null);
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
+        return fakeOuterNumberSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -480,13 +550,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, Map<String, String> headers, final ApiCallback<BigDecimal> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterNumberSerializeAsync(BigDecimal body, final ApiCallback<BigDecimal> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterNumberSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<BigDecimal>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for fakeOuterStringSerialize
      * @param body Input string as post body (optional)
@@ -499,7 +578,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeCall(String body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -526,14 +605,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call fakeOuterStringSerializeValidateBeforeCall(String body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -559,6 +644,7 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * @param body Input string as post body (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -567,10 +653,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null);
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
+        return fakeOuterStringSerializeWithHttpInfo(body, null);
     }
 
     /**
@@ -586,13 +676,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call fakeOuterStringSerializeAsync(String body, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call fakeOuterStringSerializeAsync(String body, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = fakeOuterStringSerializeValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithFileSchema
      * @param body  (required)
@@ -605,7 +704,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -632,11 +731,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithFileSchemaValidateBeforeCall(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -644,7 +749,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -668,6 +773,7 @@ public class FakeApi {
      * 
      * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -676,9 +782,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null);
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
+        return testBodyWithFileSchemaWithHttpInfo(body, null);
     }
 
     /**
@@ -694,12 +804,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithFileSchemaAsync(FileSchemaTestClass body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithFileSchemaValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testBodyWithQueryParams
      * @param query  (required)
@@ -713,7 +831,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -744,11 +862,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testBodyWithQueryParamsValidateBeforeCall(String query, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'query' is set
         if (query == null) {
@@ -761,7 +885,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsCall(query, body, headers, _callback);
         return localVarCall;
 
     }
@@ -787,6 +911,7 @@ public class FakeApi {
      * 
      * @param query  (required)
      * @param body  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -795,9 +920,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null);
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
+        return testBodyWithQueryParamsWithHttpInfo(query, body, null);
     }
 
     /**
@@ -814,12 +943,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, _callback);
+        okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testBodyWithQueryParamsAsync(String query, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testBodyWithQueryParamsValidateBeforeCall(query, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testClientModel
      * @param body client model (required)
@@ -832,7 +969,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClientModelCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -859,11 +996,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClientModelValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClientModelValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -871,7 +1014,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testClientModelCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -897,6 +1040,7 @@ public class FakeApi {
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -905,10 +1049,14 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
+        return testClientModelWithHttpInfo(body, null);
     }
 
     /**
@@ -924,13 +1072,22 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClientModelAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClientModelAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClientModelValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEndpointParameters
      * @param number None (required)
@@ -957,7 +1114,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1040,11 +1197,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "http_basic_test" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEndpointParametersValidateBeforeCall(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'number' is set
         if (number == null) {
@@ -1067,7 +1230,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         return localVarCall;
 
     }
@@ -1118,6 +1281,7 @@ public class FakeApi {
      * @param dateTime None (optional)
      * @param password None (optional)
      * @param paramCallback None (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1127,9 +1291,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
+        return testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null);
     }
 
     /**
@@ -1159,12 +1327,20 @@ public class FakeApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, _callback);
+        okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testEndpointParametersAsync(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEndpointParametersValidateBeforeCall(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testEnumParameters
      * @param enumHeaderStringArray Header parameter enum test (string array) (optional)
@@ -1185,7 +1361,7 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1244,14 +1420,20 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testEnumParametersValidateBeforeCall(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         return localVarCall;
 
     }
@@ -1290,6 +1472,7 @@ public class FakeApi {
      * @param enumQueryDouble Query parameter enum test (double) (optional)
      * @param enumFormStringArray Form parameter enum test (string array) (optional)
      * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1299,9 +1482,13 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
+        return testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null);
     }
 
     /**
@@ -1325,13 +1512,21 @@ public class FakeApi {
         <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, _callback);
+        okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
-    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+
+        public okhttp3.Call testEnumParametersAsync(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testEnumParametersValidateBeforeCall(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
+    private okhttp3.Call testGroupParametersCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1382,11 +1577,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testGroupParametersValidateBeforeCall(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'requiredStringGroup' is set
         if (requiredStringGroup == null) {
@@ -1404,23 +1605,35 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+        okhttp3.Call localVarCall = testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         return localVarCall;
 
     }
 
 
-    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, null);
         return localVarApiClient.execute(localVarCall);
     }
 
-    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+    private ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
+        return testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null);
+    }
 
-        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+    private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+private okhttp3.Call testGroupParametersAsync(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testGroupParametersValidateBeforeCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 
     public class APItestGroupParametersRequest {
         private final Integer requiredStringGroup;
@@ -1478,7 +1691,7 @@ public class FakeApi {
          </table>
          */
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, _callback);
+            return testGroupParametersCall(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, null, _callback);
         }
 
         /**
@@ -1552,7 +1765,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = param;
 
         // create path and map variables
@@ -1579,11 +1792,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testInlineAdditionalPropertiesValidateBeforeCall(Map<String, String> param, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1591,7 +1810,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesCall(param, headers, _callback);
         return localVarCall;
 
     }
@@ -1615,6 +1834,7 @@ public class FakeApi {
      * test inline additionalProperties
      * 
      * @param param request body (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1623,9 +1843,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null);
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
+        return testInlineAdditionalPropertiesWithHttpInfo(param, null);
     }
 
     /**
@@ -1641,12 +1865,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, _callback);
+        okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testInlineAdditionalPropertiesAsync(Map<String, String> param, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testInlineAdditionalPropertiesValidateBeforeCall(param, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testJsonFormData
      * @param param field1 (required)
@@ -1660,7 +1892,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1695,11 +1927,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testJsonFormDataValidateBeforeCall(String param, String param2, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'param' is set
         if (param == null) {
@@ -1712,7 +1950,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataCall(param, param2, headers, _callback);
         return localVarCall;
 
     }
@@ -1738,6 +1976,7 @@ public class FakeApi {
      * 
      * @param param field1 (required)
      * @param param2 field2 (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1746,9 +1985,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null);
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
+        return testJsonFormDataWithHttpInfo(param, param2, null);
     }
 
     /**
@@ -1765,12 +2008,20 @@ public class FakeApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testJsonFormDataAsync(String param, String param2, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, _callback);
+        okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testJsonFormDataAsync(String param, String param2, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testJsonFormDataValidateBeforeCall(param, param2, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for testQueryParameterCollectionFormat
      * @param pipe  (required)
@@ -1787,7 +2038,7 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1834,11 +2085,17 @@ public class FakeApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'pipe' is set
         if (pipe == null) {
@@ -1866,7 +2123,7 @@ public class FakeApi {
         }
         
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, headers, _callback);
         return localVarCall;
 
     }
@@ -1898,6 +2155,7 @@ public class FakeApi {
      * @param http  (required)
      * @param url  (required)
      * @param context  (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1906,9 +2164,13 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null);
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        return testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, null);
     }
 
     /**
@@ -1928,10 +2190,18 @@ public class FakeApi {
         <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, _callback);
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -66,7 +66,7 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameCall(Client body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testClassnameCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class FakeClassnameTags123Api {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key_query" };
-        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PATCH", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testClassnameValidateBeforeCall(Client body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testClassnameValidateBeforeCall(Client body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class FakeClassnameTags123Api {
         }
         
 
-        okhttp3.Call localVarCall = testClassnameCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -131,6 +137,7 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * @param body client model (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Client&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -139,10 +146,14 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null);
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
+        return testClassnameWithHttpInfo(body, null);
     }
 
     /**
@@ -158,11 +169,20 @@ public class FakeClassnameTags123Api {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+    public okhttp3.Call testClassnameAsync(Client body, Map<String, String> headers, final ApiCallback<Client> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Client>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call testClassnameAsync(Client body, final ApiCallback<Client> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = testClassnameValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Client>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -129,7 +129,11 @@ public class FakeClassnameTags123Api {
      </table>
      */
     public Client testClassname(Client body) throws ApiException {
-        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body);
+        ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Client testClassname(Client body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Client> localVarResp = testClassnameWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
@@ -70,7 +70,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call addPetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -97,11 +97,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call addPetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call addPetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -109,7 +115,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = addPetCall(body, _callback);
+        okhttp3.Call localVarCall = addPetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -134,6 +140,7 @@ public class PetApi {
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -143,9 +150,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null);
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
+        return addPetWithHttpInfo(body, null);
     }
 
     /**
@@ -162,12 +173,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call addPetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = addPetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call addPetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = addPetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deletePet
      * @param petId Pet id to delete (required)
@@ -182,7 +201,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deletePetCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -214,11 +233,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deletePetValidateBeforeCall(Long petId, String apiKey, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -226,7 +251,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetCall(petId, apiKey, headers, _callback);
         return localVarCall;
 
     }
@@ -253,6 +278,7 @@ public class PetApi {
      * 
      * @param petId Pet id to delete (required)
      * @param apiKey  (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -262,9 +288,13 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null);
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
+        return deletePetWithHttpInfo(petId, apiKey, null);
     }
 
     /**
@@ -282,12 +312,20 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deletePetAsync(Long petId, String apiKey, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, _callback);
+        okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deletePetAsync(Long petId, String apiKey, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deletePetValidateBeforeCall(petId, apiKey, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByStatus
      * @param status Status values that need to be considered for filter (required)
@@ -301,7 +339,7 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -332,11 +370,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByStatusValidateBeforeCall(List<String> status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'status' is set
         if (status == null) {
@@ -344,7 +388,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByStatusCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusCall(status, headers, _callback);
         return localVarCall;
 
     }
@@ -371,6 +415,7 @@ public class PetApi {
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -380,10 +425,14 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null);
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, null);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
+        return findPetsByStatusWithHttpInfo(status, null);
     }
 
     /**
@@ -400,13 +449,22 @@ public class PetApi {
         <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByStatusAsync(List<String> status, Map<String, String> headers, final ApiCallback<List<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, _callback);
+        okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, headers, _callback);
         Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call findPetsByStatusAsync(List<String> status, final ApiCallback<List<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByStatusValidateBeforeCall(status, null, _callback);
+Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for findPetsByTags
      * @param tags Tags to filter by (required)
@@ -422,7 +480,7 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -453,12 +511,18 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @Deprecated
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call findPetsByTagsValidateBeforeCall(Set<String> tags, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'tags' is set
         if (tags == null) {
@@ -466,7 +530,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = findPetsByTagsCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsCall(tags, headers, _callback);
         return localVarCall;
 
     }
@@ -495,6 +559,7 @@ public class PetApi {
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Set&lt;Pet&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -506,10 +571,14 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null);
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, null);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(Set<String> tags) throws ApiException {
+        return findPetsByTagsWithHttpInfo(tags, null);
     }
 
     /**
@@ -528,13 +597,23 @@ public class PetApi {
      * @deprecated
      */
     @Deprecated
-    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+    public okhttp3.Call findPetsByTagsAsync(Set<String> tags, Map<String, String> headers, final ApiCallback<Set<Pet>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, _callback);
+        okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, headers, _callback);
         Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+            @Deprecated
+        public okhttp3.Call findPetsByTagsAsync(Set<String> tags, final ApiCallback<Set<Pet>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = findPetsByTagsValidateBeforeCall(tags, null, _callback);
+Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getPetById
      * @param petId ID of pet to return (required)
@@ -549,7 +628,7 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdCall(Long petId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getPetByIdCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -577,11 +656,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getPetByIdValidateBeforeCall(Long petId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -589,7 +674,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = getPetByIdCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdCall(petId, headers, _callback);
         return localVarCall;
 
     }
@@ -617,6 +702,7 @@ public class PetApi {
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Pet&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -627,10 +713,14 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null);
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, null);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
+        return getPetByIdWithHttpInfo(petId, null);
     }
 
     /**
@@ -648,13 +738,22 @@ public class PetApi {
         <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+    public okhttp3.Call getPetByIdAsync(Long petId, Map<String, String> headers, final ApiCallback<Pet> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, _callback);
+        okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, headers, _callback);
         Type localVarReturnType = new TypeToken<Pet>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getPetByIdAsync(Long petId, final ApiCallback<Pet> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getPetByIdValidateBeforeCall(petId, null, _callback);
+Type localVarReturnType = new TypeToken<Pet>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePet
      * @param body Pet object that needs to be added to the store (required)
@@ -670,7 +769,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetCall(Pet body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -697,11 +796,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetValidateBeforeCall(Pet body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetValidateBeforeCall(Pet body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -709,7 +814,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -736,6 +841,7 @@ public class PetApi {
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -747,9 +853,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null);
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
+        return updatePetWithHttpInfo(body, null);
     }
 
     /**
@@ -768,12 +878,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetAsync(Pet body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetAsync(Pet body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updatePetWithForm
      * @param petId ID of pet that needs to be updated (required)
@@ -788,7 +906,7 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -824,11 +942,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updatePetWithFormValidateBeforeCall(Long petId, String name, String status, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -836,7 +960,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormCall(petId, name, status, headers, _callback);
         return localVarCall;
 
     }
@@ -864,6 +988,7 @@ public class PetApi {
      * @param petId ID of pet that needs to be updated (required)
      * @param name Updated name of the pet (optional)
      * @param status Updated status of the pet (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -872,9 +997,13 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null);
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
+        return updatePetWithFormWithHttpInfo(petId, name, status, null);
     }
 
     /**
@@ -892,12 +1021,20 @@ public class PetApi {
         <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, _callback);
+        okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updatePetWithFormAsync(Long petId, String name, String status, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updatePetWithFormValidateBeforeCall(petId, name, status, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFile
      * @param petId ID of pet to update (required)
@@ -912,7 +1049,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -948,11 +1085,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileValidateBeforeCall(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -960,7 +1103,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileCall(petId, additionalMetadata, file, headers, _callback);
         return localVarCall;
 
     }
@@ -990,6 +1133,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param additionalMetadata Additional data to pass to server (optional)
      * @param file file to upload (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -998,10 +1142,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
+        return uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
     }
 
     /**
@@ -1019,13 +1167,22 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, _callback);
+        okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileAsync(Long petId, String additionalMetadata, File file, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileValidateBeforeCall(petId, additionalMetadata, file, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for uploadFileWithRequiredFile
      * @param petId ID of pet to update (required)
@@ -1040,7 +1197,7 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1076,11 +1233,17 @@ public class PetApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "petstore_auth" };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadFileWithRequiredFileValidateBeforeCall(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -1093,7 +1256,7 @@ public class PetApi {
         }
         
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileCall(petId, requiredFile, additionalMetadata, headers, _callback);
         return localVarCall;
 
     }
@@ -1123,6 +1286,7 @@ public class PetApi {
      * @param petId ID of pet to update (required)
      * @param requiredFile file to upload (required)
      * @param additionalMetadata Additional data to pass to server (optional)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;ModelApiResponse&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -1131,10 +1295,14 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null);
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, null);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
+        return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
     }
 
     /**
@@ -1152,11 +1320,20 @@ public class PetApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+    public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, _callback);
+        okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, headers, _callback);
         Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call uploadFileWithRequiredFileAsync(Long petId, File requiredFile, String additionalMetadata, final ApiCallback<ModelApiResponse> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = uploadFileWithRequiredFileValidateBeforeCall(petId, requiredFile, additionalMetadata, null, _callback);
+Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/PetApi.java
@@ -133,7 +133,12 @@ public class PetApi {
      </table>
      */
     public void addPet(Pet body) throws ApiException {
-        addPetWithHttpInfo(body);
+        addPetWithHttpInfo(body, null);
+        
+    }
+    public void addPet(Pet body, Map<String, String> headers) throws ApiException {
+      addPetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -270,7 +275,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deletePet(Long petId, String apiKey) throws ApiException {
-        deletePetWithHttpInfo(petId, apiKey);
+        deletePetWithHttpInfo(petId, apiKey, null);
+        
+    }
+    public void deletePet(Long petId, String apiKey, Map<String, String> headers) throws ApiException {
+      deletePetWithHttpInfo(petId, apiKey, headers);
+        
     }
 
     /**
@@ -407,7 +417,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
-        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status);
+        ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, null);
+        return localVarResp.getData();
+    }
+    public List<Pet> findPetsByStatus(List<String> status, Map<String, String> headers) throws ApiException {
+      ApiResponse<List<Pet>> localVarResp = findPetsByStatusWithHttpInfo(status, headers);
         return localVarResp.getData();
     }
 
@@ -551,7 +565,11 @@ Type localVarReturnType = new TypeToken<List<Pet>>(){}.getType();
      */
     @Deprecated
     public Set<Pet> findPetsByTags(Set<String> tags) throws ApiException {
-        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags);
+        ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, null);
+        return localVarResp.getData();
+    }
+    public Set<Pet> findPetsByTags(Set<String> tags, Map<String, String> headers) throws ApiException {
+      ApiResponse<Set<Pet>> localVarResp = findPetsByTagsWithHttpInfo(tags, headers);
         return localVarResp.getData();
     }
 
@@ -694,7 +712,11 @@ Type localVarReturnType = new TypeToken<Set<Pet>>(){}.getType();
      </table>
      */
     public Pet getPetById(Long petId) throws ApiException {
-        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId);
+        ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, null);
+        return localVarResp.getData();
+    }
+    public Pet getPetById(Long petId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Pet> localVarResp = getPetByIdWithHttpInfo(petId, headers);
         return localVarResp.getData();
     }
 
@@ -834,7 +856,12 @@ Type localVarReturnType = new TypeToken<Pet>(){}.getType();
      </table>
      */
     public void updatePet(Pet body) throws ApiException {
-        updatePetWithHttpInfo(body);
+        updatePetWithHttpInfo(body, null);
+        
+    }
+    public void updatePet(Pet body, Map<String, String> headers) throws ApiException {
+      updatePetWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -979,7 +1006,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
-        updatePetWithFormWithHttpInfo(petId, name, status);
+        updatePetWithFormWithHttpInfo(petId, name, status, null);
+        
+    }
+    public void updatePetWithForm(Long petId, String name, String status, Map<String, String> headers) throws ApiException {
+      updatePetWithFormWithHttpInfo(petId, name, status, headers);
+        
     }
 
     /**
@@ -1123,7 +1155,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithHttpInfo(petId, additionalMetadata, file, headers);
         return localVarResp.getData();
     }
 
@@ -1276,7 +1312,11 @@ Type localVarReturnType = new TypeToken<ModelApiResponse>(){}.getType();
      </table>
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
-        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+        ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, null);
+        return localVarResp.getData();
+    }
+    public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata, Map<String, String> headers) throws ApiException {
+      ApiResponse<ModelApiResponse> localVarResp = uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -131,7 +131,12 @@ public class StoreApi {
      </table>
      */
     public void deleteOrder(String orderId) throws ApiException {
-        deleteOrderWithHttpInfo(orderId);
+        deleteOrderWithHttpInfo(orderId, null);
+        
+    }
+    public void deleteOrder(String orderId, Map<String, String> headers) throws ApiException {
+      deleteOrderWithHttpInfo(orderId, headers);
+        
     }
 
     /**
@@ -253,7 +258,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public Map<String, Integer> getInventory() throws ApiException {
-        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo();
+        ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(null);
+        return localVarResp.getData();
+    }
+    public Map<String, Integer> getInventory(Map<String, String> headers) throws ApiException {
+      ApiResponse<Map<String, Integer>> localVarResp = getInventoryWithHttpInfo(headers);
         return localVarResp.getData();
     }
 
@@ -387,7 +396,11 @@ Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
      </table>
      */
     public Order getOrderById(Long orderId) throws ApiException {
-        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId);
+        ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, null);
+        return localVarResp.getData();
+    }
+    public Order getOrderById(Long orderId, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = getOrderByIdWithHttpInfo(orderId, headers);
         return localVarResp.getData();
     }
 
@@ -524,7 +537,11 @@ Type localVarReturnType = new TypeToken<Order>(){}.getType();
      </table>
      */
     public Order placeOrder(Order body) throws ApiException {
-        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body);
+        ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, null);
+        return localVarResp.getData();
+    }
+    public Order placeOrder(Order body, Map<String, String> headers) throws ApiException {
+      ApiResponse<Order> localVarResp = placeOrderWithHttpInfo(body, headers);
         return localVarResp.getData();
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -67,7 +67,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderCall(String orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteOrderCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -95,11 +95,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteOrderValidateBeforeCall(String orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -107,7 +113,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteOrderCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -132,6 +138,7 @@ public class StoreApi {
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -141,9 +148,13 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null);
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
+        return deleteOrderWithHttpInfo(orderId, null);
     }
 
     /**
@@ -160,12 +171,20 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteOrderAsync(String orderId, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteOrderAsync(String orderId, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteOrderValidateBeforeCall(orderId, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getInventory
      * @param _callback Callback for upload/download progress
@@ -177,7 +196,7 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getInventoryCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -204,14 +223,20 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] { "api_key" };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getInventoryValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getInventoryValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = getInventoryCall(_callback);
+        okhttp3.Call localVarCall = getInventoryCall(headers, _callback);
         return localVarCall;
 
     }
@@ -235,6 +260,7 @@ public class StoreApi {
     /**
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -243,10 +269,14 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null);
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, null);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
+        return getInventoryWithHttpInfo(null);
     }
 
     /**
@@ -261,13 +291,22 @@ public class StoreApi {
         <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+    public okhttp3.Call getInventoryAsync(Map<String, String> headers, final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = getInventoryValidateBeforeCall(headers, _callback);
         Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getInventoryAsync(final ApiCallback<Map<String, Integer>> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getInventoryValidateBeforeCall(null, _callback);
+Type localVarReturnType = new TypeToken<Map<String, Integer>>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getOrderById
      * @param orderId ID of pet that needs to be fetched (required)
@@ -282,7 +321,7 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -310,11 +349,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getOrderByIdValidateBeforeCall(Long orderId, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -322,7 +367,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = getOrderByIdCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdCall(orderId, headers, _callback);
         return localVarCall;
 
     }
@@ -350,6 +395,7 @@ public class StoreApi {
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
      * @param orderId ID of pet that needs to be fetched (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -360,10 +406,14 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null);
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
+        return getOrderByIdWithHttpInfo(orderId, null);
     }
 
     /**
@@ -381,13 +431,22 @@ public class StoreApi {
         <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call getOrderByIdAsync(Long orderId, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, _callback);
+        okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getOrderByIdAsync(Long orderId, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getOrderByIdValidateBeforeCall(orderId, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for placeOrder
      * @param body order placed for purchasing the pet (required)
@@ -401,7 +460,7 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderCall(Order body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call placeOrderCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -428,11 +487,17 @@ public class StoreApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call placeOrderValidateBeforeCall(Order body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call placeOrderValidateBeforeCall(Order body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -440,7 +505,7 @@ public class StoreApi {
         }
         
 
-        okhttp3.Call localVarCall = placeOrderCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -467,6 +532,7 @@ public class StoreApi {
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Order&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -476,10 +542,14 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null);
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, null);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
+        return placeOrderWithHttpInfo(body, null);
     }
 
     /**
@@ -496,11 +566,20 @@ public class StoreApi {
         <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+    public okhttp3.Call placeOrderAsync(Order body, Map<String, String> headers, final ApiCallback<Order> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, headers, _callback);
         Type localVarReturnType = new TypeToken<Order>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call placeOrderAsync(Order body, final ApiCallback<Order> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = placeOrderValidateBeforeCall(body, null, _callback);
+Type localVarReturnType = new TypeToken<Order>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserCall(User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUserCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -93,11 +93,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUserValidateBeforeCall(User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUserValidateBeforeCall(User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -105,7 +111,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUserCall(body, _callback);
+        okhttp3.Call localVarCall = createUserCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -129,6 +135,7 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -137,9 +144,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUserWithHttpInfo(User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
+        return createUserWithHttpInfo(body, null);
     }
 
     /**
@@ -155,12 +166,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUserAsync(User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUserValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUserAsync(User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUserValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithArrayInput
      * @param body List of user object (required)
@@ -173,7 +192,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -200,11 +219,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithArrayInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -212,7 +237,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -236,6 +261,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -244,9 +270,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithArrayInputWithHttpInfo(body, null);
     }
 
     /**
@@ -262,12 +292,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithArrayInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithArrayInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for createUsersWithListInput
      * @param body List of user object (required)
@@ -280,7 +318,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -307,11 +345,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call createUsersWithListInputValidateBeforeCall(List<User> body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'body' is set
         if (body == null) {
@@ -319,7 +363,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = createUsersWithListInputCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputCall(body, headers, _callback);
         return localVarCall;
 
     }
@@ -343,6 +387,7 @@ public class UserApi {
      * Creates list of users with given input array
      * 
      * @param body List of user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -351,9 +396,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null);
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
+        return createUsersWithListInputWithHttpInfo(body, null);
     }
 
     /**
@@ -369,12 +418,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call createUsersWithListInputAsync(List<User> body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, _callback);
+        okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call createUsersWithListInputAsync(List<User> body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = createUsersWithListInputValidateBeforeCall(body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for deleteUser
      * @param username The name that needs to be deleted (required)
@@ -388,7 +445,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call deleteUserCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -416,11 +473,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "DELETE", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call deleteUserValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call deleteUserValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -428,7 +491,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = deleteUserCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -453,6 +516,7 @@ public class UserApi {
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -462,9 +526,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null);
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
+        return deleteUserWithHttpInfo(username, null);
     }
 
     /**
@@ -481,12 +549,20 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call deleteUserAsync(String username, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call deleteUserAsync(String username, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = deleteUserValidateBeforeCall(username, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for getUserByName
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
@@ -501,7 +577,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameCall(String username, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getUserByNameCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -529,11 +605,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getUserByNameValidateBeforeCall(String username, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getUserByNameValidateBeforeCall(String username, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -541,7 +623,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = getUserByNameCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameCall(username, headers, _callback);
         return localVarCall;
 
     }
@@ -569,6 +651,7 @@ public class UserApi {
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;User&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -579,10 +662,14 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null);
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, null);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
+        return getUserByNameWithHttpInfo(username, null);
     }
 
     /**
@@ -600,13 +687,22 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+    public okhttp3.Call getUserByNameAsync(String username, Map<String, String> headers, final ApiCallback<User> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, _callback);
+        okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, headers, _callback);
         Type localVarReturnType = new TypeToken<User>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call getUserByNameAsync(String username, final ApiCallback<User> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = getUserByNameValidateBeforeCall(username, null, _callback);
+Type localVarReturnType = new TypeToken<User>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for loginUser
      * @param username The user name for login (required)
@@ -621,7 +717,7 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call loginUserCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -656,11 +752,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call loginUserValidateBeforeCall(String username, String password, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -673,7 +775,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = loginUserCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserCall(username, password, headers, _callback);
         return localVarCall;
 
     }
@@ -702,6 +804,7 @@ public class UserApi {
      * 
      * @param username The user name for login (required)
      * @param password The password for login in clear text (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -711,10 +814,14 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null);
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
+        return loginUserWithHttpInfo(username, password, null);
     }
 
     /**
@@ -732,13 +839,22 @@ public class UserApi {
         <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call loginUserAsync(String username, String password, Map<String, String> headers, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, _callback);
+        okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, headers, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call loginUserAsync(String username, String password, final ApiCallback<String> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = loginUserValidateBeforeCall(username, password, null, _callback);
+Type localVarReturnType = new TypeToken<String>(){}.getType();
+    localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for logoutUser
      * @param _callback Callback for upload/download progress
@@ -750,7 +866,7 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserCall(final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logoutUserCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -777,14 +893,20 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logoutUserValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logoutUserValidateBeforeCall(Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
 
-        okhttp3.Call localVarCall = logoutUserCall(_callback);
+        okhttp3.Call localVarCall = logoutUserCall(headers, _callback);
         return localVarCall;
 
     }
@@ -806,6 +928,7 @@ public class UserApi {
     /**
      * Logs out current logged in user session
      * 
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -814,9 +937,13 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null);
+    public ApiResponse<Void> logoutUserWithHttpInfo(Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
+        return logoutUserWithHttpInfo(null);
     }
 
     /**
@@ -831,12 +958,20 @@ public class UserApi {
         <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call logoutUserAsync(Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(_callback);
+        okhttp3.Call localVarCall = logoutUserValidateBeforeCall(headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call logoutUserAsync(final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = logoutUserValidateBeforeCall(null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
     /**
      * Build call for updateUser
      * @param username name that need to be deleted (required)
@@ -851,7 +986,7 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call updateUserCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = body;
 
         // create path and map variables
@@ -879,11 +1014,17 @@ public class UserApi {
         localVarHeaderParams.put("Content-Type", localVarContentType);
 
         String[] localVarAuthNames = new String[] {  };
-        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+        localVarApiClient.updateParamsForAuth(localVarAuthNames, localVarQueryParams, localVarHeaderParams, localVarCookieParams);
+
+        if (headers != null) {
+          localVarHeaderParams.putAll(headers);
+        }
+
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, _callback);
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call updateUserValidateBeforeCall(String username, User body, Map<String, String> headers, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -896,7 +1037,7 @@ public class UserApi {
         }
         
 
-        okhttp3.Call localVarCall = updateUserCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserCall(username, body, headers, _callback);
         return localVarCall;
 
     }
@@ -923,6 +1064,7 @@ public class UserApi {
      * This can only be done by the logged in user.
      * @param username name that need to be deleted (required)
      * @param body Updated user object (required)
+     * @param headers Map of HTTP headers that will override other headers. For example, you can specify Auth headers per request.
      * @return ApiResponse&lt;Void&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -932,9 +1074,13 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null);
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body, Map<String, String> headers) throws ApiException {
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, null);
         return localVarApiClient.execute(localVarCall);
+    }
+
+    public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
+        return updateUserWithHttpInfo(username, body, null);
     }
 
     /**
@@ -952,10 +1098,18 @@ public class UserApi {
         <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+    public okhttp3.Call updateUserAsync(String username, User body, Map<String, String> headers, final ApiCallback<Void> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, _callback);
+        okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, headers, _callback);
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+
+        public okhttp3.Call updateUserAsync(String username, User body, final ApiCallback<Void> _callback) throws ApiException {
+
+    okhttp3.Call localVarCall = updateUserValidateBeforeCall(username, body, null, _callback);
+localVarApiClient.executeAsync(localVarCall, _callback);
+    return localVarCall;
+    }
+
 }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -128,7 +128,12 @@ public class UserApi {
      </table>
      */
     public void createUser(User body) throws ApiException {
-        createUserWithHttpInfo(body);
+        createUserWithHttpInfo(body, null);
+        
+    }
+    public void createUser(User body, Map<String, String> headers) throws ApiException {
+      createUserWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -254,7 +259,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithArrayInput(List<User> body) throws ApiException {
-        createUsersWithArrayInputWithHttpInfo(body);
+        createUsersWithArrayInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithArrayInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithArrayInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -380,7 +390,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void createUsersWithListInput(List<User> body) throws ApiException {
-        createUsersWithListInputWithHttpInfo(body);
+        createUsersWithListInputWithHttpInfo(body, null);
+        
+    }
+    public void createUsersWithListInput(List<User> body, Map<String, String> headers) throws ApiException {
+      createUsersWithListInputWithHttpInfo(body, headers);
+        
     }
 
     /**
@@ -509,7 +524,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void deleteUser(String username) throws ApiException {
-        deleteUserWithHttpInfo(username);
+        deleteUserWithHttpInfo(username, null);
+        
+    }
+    public void deleteUser(String username, Map<String, String> headers) throws ApiException {
+      deleteUserWithHttpInfo(username, headers);
+        
     }
 
     /**
@@ -643,7 +663,11 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public User getUserByName(String username) throws ApiException {
-        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username);
+        ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, null);
+        return localVarResp.getData();
+    }
+    public User getUserByName(String username, Map<String, String> headers) throws ApiException {
+      ApiResponse<User> localVarResp = getUserByNameWithHttpInfo(username, headers);
         return localVarResp.getData();
     }
 
@@ -795,7 +819,11 @@ Type localVarReturnType = new TypeToken<User>(){}.getType();
      </table>
      */
     public String loginUser(String username, String password) throws ApiException {
-        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password);
+        ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, null);
+        return localVarResp.getData();
+    }
+    public String loginUser(String username, String password, Map<String, String> headers) throws ApiException {
+      ApiResponse<String> localVarResp = loginUserWithHttpInfo(username, password, headers);
         return localVarResp.getData();
     }
 
@@ -922,7 +950,12 @@ Type localVarReturnType = new TypeToken<String>(){}.getType();
      </table>
      */
     public void logoutUser() throws ApiException {
-        logoutUserWithHttpInfo();
+        logoutUserWithHttpInfo(null);
+        
+    }
+    public void logoutUser(Map<String, String> headers) throws ApiException {
+      logoutUserWithHttpInfo(headers);
+        
     }
 
     /**
@@ -1056,7 +1089,12 @@ localVarApiClient.executeAsync(localVarCall, _callback);
      </table>
      */
     public void updateUser(String username, User body) throws ApiException {
-        updateUserWithHttpInfo(username, body);
+        updateUserWithHttpInfo(username, body, null);
+        
+    }
+    public void updateUser(String username, User body, Map<String, String> headers) throws ApiException {
+      updateUserWithHttpInfo(username, body, headers);
+        
     }
 
     /**

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -159,6 +159,14 @@ public class PetApiTest {
     }
 
     @Test
+    public void testHeaderOverrides() throws Exception {
+        Pet pet = createPet();
+        Map<String, String> headers = new HashMap<>();
+        api.addPet(pet, headers);
+        //todo finish writing this test
+    }
+
+    @Test
     public void testCreateAndGetPetAsyncInvalidID() throws Exception {
         Pet pet = createPet();
         api.addPet(pet);

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -162,8 +162,14 @@ public class PetApiTest {
     public void testHeaderOverrides() throws Exception {
         Pet pet = createPet();
         Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer: asdfasdf");
+
+        // Smoketest that the template creates method signature correctly
         api.addPet(pet, headers);
-        //todo finish writing this test
+
+        okhttp3.Call call = api.addPetCall(pet, headers, null);
+        Assert.assertTrue(false);
+        Assert.assertEquals("Bearer: asdfasdf", call.request().header("Authorization"));
     }
 
     @Test

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -168,7 +168,6 @@ public class PetApiTest {
         api.addPet(pet, headers);
 
         okhttp3.Call call = api.addPetCall(pet, headers, null);
-        Assert.assertTrue(false);
         Assert.assertEquals("Bearer: asdfasdf", call.request().header("Authorization"));
     }
 


### PR DESCRIPTION
Upstream issue: https://github.com/OpenAPITools/openapi-generator/issues/9792
Upstream PR: https://github.com/OpenAPITools/openapi-generator/pull/9820

We want to use a shared connection, but want to specify different JWT for each request. This has to be done by overloading the calls (some calls have no params or primitive params, so I need to have a new param). I implemented as a headers map to be more generally useful.

I added a Map<String, String> headers to the client calls, and passed it down the stack.

While I was fixing, I found it difficult to reason about when these headers were being modified, because the String[] authNames parameter was kind of goofy, and all the request headers were not modified in the same place -- I changed the code to now do all the header changes/mutations in one place. This makes it easier to know for certain that any headers intended to override are in fact added after all other mutations to the headers.

See the One Pager for details:
https://confluentinc.atlassian.net/wiki/spaces/Engineering/pages/2425390787/OpenAPI+Java+SDK+Generator+with+JWT?focusedCommentId=2425393590#comment-2425393590