### PR TITLE
Put a snippet of Apache License, Version 2.0 to every generated go file

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/apl_v2_header.mustache
+++ b/modules/openapi-generator/src/main/resources/go/apl_v2_header.mustache
@@ -1,0 +1,13 @@
+// Copyright 2021 Confluent Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/modules/openapi-generator/src/main/resources/go/partial_header.mustache
+++ b/modules/openapi-generator/src/main/resources/go/partial_header.mustache
@@ -1,3 +1,4 @@
+{{>apl_v2_header}}
 /*
 {{#appName}}
 {{{.}}}


### PR DESCRIPTION
### What
Add a header that references `Apache License, Version 2.0` to every generated go file.

### Test
```
➜  openapi-generator git:(add-apl-v2) mvn clean install -DskipTests -Dmaven.javadoc.skip=true      

# an explicit command for sdk-go from Makefile                            
➜  openapi-generator git:(add-apl-v2) java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g go \
                -i ../api/cmk/docs.yaml -o ../api/cmk/sdk/go \
                --package-name v2 \
                --generate-alias-as-model \
                --enable-post-process-file \
                --git-user-id confluentinc \
                --git-repo-id ccloud-sdk-go-v2 \
                --additional-properties=useOneOfDiscriminatorLookup=true

```
![image](https://user-images.githubusercontent.com/5459870/131928504-4426bf19-8811-44d6-bbf5-8b4c932dd13e.png)



